### PR TITLE
[BUGFIX] Amend folder name to be included

### DIFF
--- a/Configuration/TsConfig/Page/GridElements.tsconfig
+++ b/Configuration/TsConfig/Page/GridElements.tsconfig
@@ -1,4 +1,4 @@
 ######################
 #### GRIDELEMENTS ####
 ######################
-<INCLUDE_TYPOSCRIPT: source="DIR:EXT:autogrids/Configuration/TsConfig/Page/Gridelements" extensions="tsconfig">
+<INCLUDE_TYPOSCRIPT: source="DIR:EXT:autogrids/Configuration/TsConfig/Page/GridElements" extensions="tsconfig">


### PR DESCRIPTION
When using nfs mount, e.g. windows + ddev with the option "nfs_mount_enabled: true", the folder name has to be written case sensitive, properly.